### PR TITLE
add micropython RP2040 i2c driver

### DIFF
--- a/qwiic_i2c/__init__.py
+++ b/qwiic_i2c/__init__.py
@@ -66,8 +66,9 @@ New to qwiic? Take a look at the entire [SparkFun qwiic ecosystem](https://www.s
 from .i2c_driver 	import I2CDriver
 from .linux_i2c 	import LinuxI2C
 from .circuitpy_i2c import CircuitPythonI2C
+from .micropython_rp2040_i2c import MicroPythonRP2040I2C
 
-_drivers = [LinuxI2C, CircuitPythonI2C]
+_drivers = [LinuxI2C, CircuitPythonI2C, MicroPythonRP2040I2C]
 
 _theDriver = None
 

--- a/qwiic_i2c/__init__.py
+++ b/qwiic_i2c/__init__.py
@@ -65,36 +65,22 @@ New to qwiic? Take a look at the entire [SparkFun qwiic ecosystem](https://www.s
 # Drivers and driver baseclass
 from .i2c_driver import I2CDriver
 
+# All supported platform module and class names
+sub_modules = ["linux_i2c", "circuitpy_i2c", "micropython_i2c"]
+class_names = ["LinuxI2C", "CircuitPythonI2C", "MicroPythonI2C"]
+
+# List of platform drivers found on this system
 _drivers = []
-# foo = ["LinuxI2C", "CircuitPythonI2C", "MicroPythonI2C"]
 
-# for driver in foo:
-# 	try:
-# 		print("Importing:", driver)
-# 		submodule = __import__(driver)
-# 		print("Submodule:", submodule)
-# 		_drivers.append(submodule)
-# 	except:
-# 		print("Could not import:", driver)
-# 		pass
-
-try:
-	from .linux_i2c import LinuxI2C
-	_drivers.append(LinuxI2C)
-except:
-	pass
-
-try:
-	from .circuitpy_i2c import CircuitPythonI2C
-	_drivers.append(CircuitPythonI2C)
-except:
-	pass
-
-try:
-	from .micropython_i2c import MicroPythonI2C
-	_drivers.append(MicroPythonI2C)
-except:
-	pass
+# Loop through all supported platform drivers, see if they're included, and
+# append them to the driver list if so
+for i in range(len(sub_modules)):
+	try:
+		full_name = "qwiic_i2c." + sub_modules[i]
+		sub_module = __import__(full_name, None, None, [None])
+		_drivers.append(getattr(sub_module, class_names[i]))
+	except:
+		pass
 
 _theDriver = None
 

--- a/qwiic_i2c/__init__.py
+++ b/qwiic_i2c/__init__.py
@@ -64,11 +64,26 @@ New to qwiic? Take a look at the entire [SparkFun qwiic ecosystem](https://www.s
 #-----------------------------------------------------------------------------
 # Drivers and driver baseclass
 from .i2c_driver 	import I2CDriver
-from .linux_i2c 	import LinuxI2C
-from .circuitpy_i2c import CircuitPythonI2C
-from .micropython_rp2040_i2c import MicroPythonRP2040I2C
 
-_drivers = [LinuxI2C, CircuitPythonI2C, MicroPythonRP2040I2C]
+_drivers = []
+
+try:
+	from .linux_i2c import LinuxI2C
+	_drivers.append(LinuxI2C)
+except:
+	pass
+
+try:
+	from .circuitpy_i2c import CircuitPythonI2C
+	_drivers.append(CircuitPythonI2C)
+except:
+	pass
+
+try:
+	from .micropython_i2c import MicroPythonI2C
+	_drivers.append(MicroPythonI2C)
+except:
+	pass
 
 _theDriver = None
 

--- a/qwiic_i2c/__init__.py
+++ b/qwiic_i2c/__init__.py
@@ -63,9 +63,20 @@ New to qwiic? Take a look at the entire [SparkFun qwiic ecosystem](https://www.s
 #
 #-----------------------------------------------------------------------------
 # Drivers and driver baseclass
-from .i2c_driver 	import I2CDriver
+from .i2c_driver import I2CDriver
 
 _drivers = []
+# foo = ["LinuxI2C", "CircuitPythonI2C", "MicroPythonI2C"]
+
+# for driver in foo:
+# 	try:
+# 		print("Importing:", driver)
+# 		submodule = __import__(driver)
+# 		print("Submodule:", submodule)
+# 		_drivers.append(submodule)
+# 	except:
+# 		print("Could not import:", driver)
+# 		pass
 
 try:
 	from .linux_i2c import LinuxI2C

--- a/qwiic_i2c/__init__.py
+++ b/qwiic_i2c/__init__.py
@@ -66,19 +66,21 @@ New to qwiic? Take a look at the entire [SparkFun qwiic ecosystem](https://www.s
 from .i2c_driver import I2CDriver
 
 # All supported platform module and class names
-sub_modules = ["linux_i2c", "circuitpy_i2c", "micropython_i2c"]
-class_names = ["LinuxI2C", "CircuitPythonI2C", "MicroPythonI2C"]
+_supported_platforms = {
+	"linux_i2c": "LinuxI2C",
+	"circuitpy_i2c": "CircuitPythonI2C",
+	"micropython_i2c": "MicroPythonI2C"
+}
 
 # List of platform drivers found on this system
 _drivers = []
 
 # Loop through all supported platform drivers, see if they're included, and
 # append them to the driver list if so
-for i in range(len(sub_modules)):
+for module_name, class_name in _supported_platforms.items():
 	try:
-		full_name = "qwiic_i2c." + sub_modules[i]
-		sub_module = __import__(full_name, None, None, [None])
-		_drivers.append(getattr(sub_module, class_names[i]))
+		sub_module = __import__("qwiic_i2c." + module_name, None, None, [None])
+		_drivers.append(getattr(sub_module, class_name))
 	except:
 		pass
 

--- a/qwiic_i2c/micropython_i2c.py
+++ b/qwiic_i2c/micropython_i2c.py
@@ -97,40 +97,28 @@ class MicroPythonI2C(I2CDriver):
 
 	# read commands ----------------------------------------------------------
 	def readWord(self, address, commandCode):
-		buffer = bytearray(2)
-		self.i2cbus.writeto(address, bytes([commandCode]), False)
-		self.i2cbus.readfrom_into(address, buffer)
+		buffer = self.i2cbus.readfrom_mem(address, commandCode, 2)
 		return (buffer[1] << 8 ) | buffer[0]
 
 	def readByte(self, address, commandCode):
-		buffer = bytearray(1)
-		self.i2cbus.writeto(address, bytes([commandCode]), False)
-		self.i2cbus.readfrom_into(address, buffer)
-		return buffer[0]
+		return self.i2cbus.readfrom_mem(address, commandCode, 1)[0]
 
 	def readBlock(self, address, commandCode, nBytes):
-		buffer = bytearray(nBytes)
-		self.i2cbus.writeto(address, bytes([commandCode]), False)
-		self.i2cbus.readfrom_into(address, buffer)
-		return buffer
+		return self.i2cbus.readfrom_mem(address, commandCode, nBytes)
 
 		
 	# write commands----------------------------------------------------------
 	def writeCommand(self, address, commandCode):
-		self.i2cbus.writeto(address, bytes([commandCode]))
+		self.i2cbus.writeto(address, commandCode.to_bytes(1, 'little'))
 
 	def writeWord(self, address, commandCode, value):
-		buffer = bytearray(2)
-		buffer[0] = value & 0xFF
-		buffer[1] = (value >> 8) & 0xFF
-		self.i2cbus.writeto(address, bytes(bytes([commandCode]) + buffer), False)
+		self.i2cbus.writeto_mem(address, commandCode, value.to_bytes(2, 'little'))
 
 	def writeByte(self, address, commandCode, value):
-		self.i2cbus.writeto(address, bytes([commandCode, value]))
+		self.i2cbus.writeto_mem(address, commandCode, value.to_bytes(1, 'little'))
 
 	def writeBlock(self, address, commandCode, value):
-		data = [value] if not isinstance(value, list) else value
-		self.i2cbus.writeto(address, bytes(bytes([commandCode]) + bytes(data)), False)
+		self.i2cbus.writeto_mem(address, commandCode, bytes(value))
 
 
 	# scan -------------------------------------------------------------------

--- a/qwiic_i2c/micropython_i2c.py
+++ b/qwiic_i2c/micropython_i2c.py
@@ -1,7 +1,7 @@
 #-----------------------------------------------------------------------------
-# micropython_rp2040_i2c.py
+# micropython_i2c.py
 #
-# Encapsulate RP2040 MicroPython port I2C interface
+# Encapsulate MicroPython port I2C interface
 #------------------------------------------------------------------------
 #
 # Written by  oclyke, Feb 2021

--- a/qwiic_i2c/micropython_i2c.py
+++ b/qwiic_i2c/micropython_i2c.py
@@ -36,23 +36,21 @@
 from .i2c_driver import I2CDriver
 
 import sys
-import os
 
-
-_PLATFORM_NAME = "RP2040 MicroPython"
+_PLATFORM_NAME = "MicroPython"
 
 # used internally in this file to get i2c class object 
 def _connectToI2CBus(freq=400000):
 	try:
-		import board
-		from machine import I2C
-		return I2C(id=board.qwiic_id, scl=board.qwiic_scl, sda=board.qwiic_sda, freq=freq)
+		from machine import I2C, Pin
+		# Todo: Don't hard code I2C pin and port!
+		return I2C(id=1, scl=Pin(19), sda=Pin(18), freq=freq)
 	except Exception as e:
 		print(str(e))
 		print('error: failed to connect to i2c bus')
 	return None
 
-class MicroPythonRP2040I2C(I2CDriver):
+class MicroPythonI2C(I2CDriver):
 
 	# Constructor
 	name = _PLATFORM_NAME
@@ -63,7 +61,10 @@ class MicroPythonRP2040I2C(I2CDriver):
 
 	@classmethod
 	def isPlatform(cls):
-		return os.uname().sysname in ['rp2']
+		try:
+			return sys.implementation.name == 'micropython'
+		except:
+			return False
 
 
 #-------------------------------------------------------------------------		

--- a/qwiic_i2c/micropython_rp2040_i2c.py
+++ b/qwiic_i2c/micropython_rp2040_i2c.py
@@ -1,0 +1,149 @@
+#-----------------------------------------------------------------------------
+# micropython_rp2040_i2c.py
+#
+# Encapsulate RP2040 MicroPython port I2C interface
+#------------------------------------------------------------------------
+#
+# Written by  oclyke, Feb 2021
+# 
+#
+# More information on qwiic is at https://www.sparkfun.com/qwiic
+#
+# Do you like this library? Help support SparkFun. Buy a board!
+#
+#==================================================================================
+# Copyright (c) 2021 SparkFun Electronics
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy 
+# of this software and associated documentation files (the "Software"), to deal 
+# in the Software without restriction, including without limitation the rights 
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+# copies of the Software, and to permit persons to whom the Software is 
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all 
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+# SOFTWARE.
+#==================================================================================
+
+from .i2c_driver import I2CDriver
+
+import sys
+import os
+
+
+_PLATFORM_NAME = "RP2040 MicroPython"
+
+# used internally in this file to get i2c class object 
+def _connectToI2CBus(id, freq=400000):
+	try:
+		from machine import I2C
+		return I2C(id=id, freq=freq)
+	except Exception as e:
+		print(str(e))
+		print('error: failed to connect to i2c bus')
+	return None
+
+class MicroPythonRP2040I2C(I2CDriver):
+
+	# Constructor
+	name = _PLATFORM_NAME
+	_i2cbus = None
+	_i2c_port_id = 0
+
+	def __init__(self):
+		I2CDriver.__init__(self) # init super
+
+	@classmethod
+	def isPlatform(cls):
+		return os.uname().sysname in ['rp2']
+
+
+#-------------------------------------------------------------------------		
+	# General get attribute method
+	#
+	# Used to intercept getting the I2C bus object - so we can perform a lazy
+	# connect ....
+	#
+	def __getattr__(self, name):
+
+		if(name == "i2cbus"):
+			if( self._i2cbus == None):
+				self._i2cbus = _connectToI2CBus(self._i2c_port_id)
+			return self._i2cbus
+
+		else:
+			# Note - we call __getattribute__ to the super class (object).
+			return super(I2CDriver, self).__getattribute__(name)
+
+	#-------------------------------------------------------------------------
+	# General set attribute method
+	#
+	# Basically implemented to make the i2cbus attribute readonly to users 
+	# of this class. 
+	#
+	def __setattr__(self, name, value):
+
+		if(name != "i2cbus"):
+			super(I2CDriver, self).__setattr__(name, value)
+
+	# read commands ----------------------------------------------------------
+	def readWord(self, address, commandCode):
+		buffer = bytearray(2)
+		self.i2cbus.writeto(address, commandCode, False)
+		self.i2cbus.readfrom_into(address, buffer)
+		return (buffer[1] << 8 ) | buffer[0]
+
+	def readByte(self, address, commandCode):
+		buffer = bytearray(1)
+		self.i2cbus.writeto(address, commandCode, False)
+		self.i2cbus.readfrom_into(address, buffer)
+		return buffer
+
+	def readBlock(self, address, commandCode, nBytes):
+		buffer = bytearray(nBytes)
+		self.i2cbus.writeto(address, commandCode, False)
+		self.i2cbus.readfrom_into(address, buffer)
+		return buffer
+
+		
+	# write commands----------------------------------------------------------
+	def writeCommand(self, address, commandCode):
+		self.i2cbus.writeto(address, commandCode)
+
+	def writeWord(self, address, commandCode, value):
+		buffer = bytearray(2)
+		buffer[0] = value & 0xFF
+		buffer[1] = (value >> 8) & 0xFF
+		self.i2cbus.writeto(address, commandCode, False)
+		self.i2cbus.writeto(address, buffer)		
+
+	def writeByte(self, address, commandCode, value):
+		self.i2cbus.writeto(address, commandCode, False)
+		self.i2cbus.writeto(address, bytes(value))		
+
+	def writeBlock(self, address, commandCode, value):
+		data = [value] if isinstance(value, list) else value
+		self.i2cbus.writeto(address, commandCode, False)
+		self.i2cbus.writeto(address, data)
+
+
+	# scan -------------------------------------------------------------------
+	@classmethod
+	def scan(cls):
+		""" Returns a list of addresses for the devices connected to the I2C bus."""
+	
+		if cls._i2cbus == None:
+			cls._i2cbus = _connectToI2CBus(cls._i2c_port_id)
+	
+		if cls._i2cbus == None:
+			return []
+			
+		return cls._i2cbus.scan()

--- a/qwiic_i2c/micropython_rp2040_i2c.py
+++ b/qwiic_i2c/micropython_rp2040_i2c.py
@@ -122,16 +122,14 @@ class MicroPythonRP2040I2C(I2CDriver):
 		buffer = bytearray(2)
 		buffer[0] = value & 0xFF
 		buffer[1] = (value >> 8) & 0xFF
-		self.i2cbus.writeto(address, bytes([commandCode]), False)
-		self.i2cbus.write(address, bytes(buffer))
+		self.i2cbus.writeto(address, bytes(bytes([commandCode]) + buffer), False)
 
 	def writeByte(self, address, commandCode, value):
 		self.i2cbus.writeto(address, bytes([commandCode, value]))
 
 	def writeBlock(self, address, commandCode, value):
 		data = [value] if not isinstance(value, list) else value
-		self.i2cbus.writeto(address, bytes([commandCode]), False)
-		self.i2cbus.write(bytes(data))
+		self.i2cbus.writeto(address, bytes(bytes([commandCode]) + bytes(data)), False)
 
 
 	# scan -------------------------------------------------------------------

--- a/qwiic_i2c/micropython_rp2040_i2c.py
+++ b/qwiic_i2c/micropython_rp2040_i2c.py
@@ -123,16 +123,15 @@ class MicroPythonRP2040I2C(I2CDriver):
 		buffer[0] = value & 0xFF
 		buffer[1] = (value >> 8) & 0xFF
 		self.i2cbus.writeto(address, bytes([commandCode]), False)
-		self.i2cbus.writeto(address, bytes(buffer))		
+		self.i2cbus.write(address, bytes(buffer))
 
 	def writeByte(self, address, commandCode, value):
-		self.i2cbus.writeto(address, bytes([commandCode]), False)
-		self.i2cbus.writeto(address, bytes([value]))		
+		self.i2cbus.writeto(address, bytes([commandCode, value]))
 
 	def writeBlock(self, address, commandCode, value):
 		data = [value] if not isinstance(value, list) else value
 		self.i2cbus.writeto(address, bytes([commandCode]), False)
-		self.i2cbus.writeto(address, bytes(data))
+		self.i2cbus.write(bytes(data))
 
 
 	# scan -------------------------------------------------------------------


### PR DESCRIPTION
**what it do**
adds an i2c driver that is compatible with the RP2040 port of micropython

**depended on by**
[add support for micropython on RP2040 boards](https://github.com/sparkfun/Qwiic_Py/pull/14)

**status**
✅ i2c driver seems to work