### PR TITLE
Fix setup.py by removing DESCRIPTION.rst file access.

### DIFF
--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -1,4 +1,4 @@
 Qwiic I2C Driver
 ==========================
 
-This package provdes support cross platform I2C support for the qwiic python packages
+This package provides cross platform I2C support for the qwiic python packages

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     version='0.9.11',
 
     description='SparkFun Electronics qwiic I2C library',
-    long_description='This package provdes support cross platform I2C support for the qwiic python packages',
+    long_description='This package provides cross platform I2C support for the qwiic python packages',
 
     # The project's main homepage.
     url='http://www.sparkfun.com/qwiic',

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,6 @@ import io
 
 here = path.abspath(path.dirname(__file__))
 
-# get the log description from the decription file
-with io.open(path.join(here, "DESCRIPTION.rst"), encoding="utf-8") as f:
-    long_description = f.read()
-
 setup_requires = []
 setup_requires.append("smbus2")
 
@@ -58,7 +54,7 @@ setup(
     version='0.9.11',
 
     description='SparkFun Electronics qwiic I2C library',
-    long_description=long_description,
+    long_description='This package provdes support cross platform I2C support for the qwiic python packages',
 
     # The project's main homepage.
     url='http://www.sparkfun.com/qwiic',


### PR DESCRIPTION
DESCRIPTION.rst is not included in the PyPi package. Using setup.py from the PyPi tarball results in the following error:
```
Traceback (most recent call last):
  File "setup.py", line 45, in <module>
    with io.open(path.join(here, "DESCRIPTION.rst"), encoding="utf-8") as f:
FileNotFoundError: [Errno 2] No such file or directory: '/home/brandon/Qwiic_I2C_Py/DESCRIPTION.rst'
```