### PR TITLE
linux_i2c: Set the iBus as environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Examples
 ---------------
 This package is used extensively by the python modules for the SparkFun qwiic ecosystem. References to the modules can be found in the [qwiic python package](https://github.com/sparkfun/Qwiic_Py/tree/master/drivers)
 
+> :warning: In Linux environments, the default I2C Bus used is
+i2c1. This may be overriden by exporting the environment variable
+`QWIIC_I2C_BUS` to point to the correct I2C Bus.
+
 General package use examples:
 
 ```python

--- a/qwiic_i2c/linux_i2c.py
+++ b/qwiic_i2c/linux_i2c.py
@@ -41,6 +41,7 @@ from __future__ import print_function
 from .i2c_driver import I2CDriver
 
 import sys
+import os
 
 
 _PLATFORM_NAME = "Linux"
@@ -60,7 +61,7 @@ def _connectToI2CBus():
 		print("Error: Unable to load smbus module. Unable to continue", file=sys.stderr)
 		return None
 
-	iBus = 1
+	iBus = int(os.environ.get('QWIIC_I2C_BUS', 1))
 	daBus = None
 
 	error=False


### PR DESCRIPTION
One of the possible problems folks face is when multiple i2c bus is used for various functions, in such cases, the dt_overlay mechanism to setup the board to map the desired i2cbus to i2c1 may not be available for various reasons.

See [1][2][3] as examples. Lets just skip this problem by allowing people to quickly prototype solutions by exporting the I2C bus - though this solution will not nicely scale if there are additional qwiic connectors on the board which need to be controlled by the same application script.

[1] https://forum.sparkfun.com/viewtopic.php?f=105&t=54688 [2] https://github.com/sparkfun/Qwiic_I2C_Py/pull/1 [3] https://github.com/sparkfun/Qwiic_I2C_Py/pull/8

Signed-off-by: Nishanth Menon <nm@ti.com>