### PR TITLE
Support for current CircuitPython Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 Qwiic_I2C_Py
 ==============
 
+
+This is a fork of the main Qwiic_I2C_Py Repo. It has been updated to work with the current CircuitPython Version (7.3.3) and support for the ESP32-S3 has been added.
+Currently only ReadByte and WriteByte have been fully tested.
+
 <p align="center">
    <img src="https://cdn.sparkfun.com/assets/custom_pages/2/7/2/qwiic-logo-registered.jpg"  width=200>  
    <img src="https://www.python.org/static/community_logos/python-logo-master-v3-TM.png"  width=240>   

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@ Qwiic_I2C_Py
 ==============
 
 
-This is a fork of the main Qwiic_I2C_Py Repo. It has been updated to work with the current CircuitPython Version (7.3.3) and support for the ESP32-S3 has been added.
-Currently only ReadByte and WriteByte have been fully tested.
+This is a fork of the main Qwiic_I2C_Py Repo. It has been updated to work with the current CircuitPython Version (8.0.4). It should support the ESP32 and family(S2,S3,C3), RP2040, STM32, and SAMD51 and 21. Currently I have only tested it on SAMD51, and ESP32 S2 and S3. Currently only ReadByte and WriteByte have been fully tested.
 
 <p align="center">
    <img src="https://cdn.sparkfun.com/assets/custom_pages/2/7/2/qwiic-logo-registered.jpg"  width=200>  

--- a/qwiic_i2c/circuitpy_i2c.py
+++ b/qwiic_i2c/circuitpy_i2c.py
@@ -110,8 +110,7 @@ class CircuitPythonI2C(I2CDriver):
 	@classmethod
 	def isPlatform(cls):
 
-		# circuit py is mostly - for our purposes - on the samd21 or samd51 based boards
-		return os.uname().sysname in ('samd21', 'samd51','ESP32S3')
+		return os.uname().sysname in ('ESP32','ESP32S2','ESP32S3','ESP32C3','rp2040', 'stm32','samd21', 'samd51')
 
 
 #-------------------------------------------------------------------------		

--- a/qwiic_i2c/circuitpy_i2c.py
+++ b/qwiic_i2c/circuitpy_i2c.py
@@ -63,21 +63,34 @@ def _connectToI2CBus():
 	daBus = None
 
 	error=False
-
+	msg_a = ""
+	msg_b = ""
+	msg_c = ""
 	# Connect - catch errors 
 
-	try:
-		daBus =  board.STEMMA_I2C()
-        #daBus = busio.I2C(board.STEMMA_I2C())
-	except Exception as ee:
-		if type(ee) is RuntimeError:
-			print("Error:\tUnable to connect to I2C bus. %s" % (ee))
-			print("\t\tEnsure a board is connected to the %s board." % (os.uname().machine))			
-		else:
-			print("Error:\tFailed to connect to I2C bus. Error: %s" % (ee))
 
+	try:
+		daBus =  busio.I2C(board.SCL, board.SDA)
+	except Exception:
+		if type(Exception) is RuntimeError:
+			msg_a = "Error:\tUnable to connect to I2C bus. %s" % (Exception)
+			msg_b = "\t\tEnsure a board is connected to the %s board." % (os.uname().machine)		
+		else:
+			msg_c = "Error:\tFailed to connect to I2C bus. Error: %s" % (Exception)
 		# We had an error.... 
 		error=True
+
+	#If the first way connecting to I2C doesnt work, try this alternate way before printing exceptions
+	if error == True:
+		try:
+			daBus = board.STEMMA_I2C()
+			error = False
+		except:
+			if type(Exception) is RuntimeError:
+				print(msg_a)
+				print(msg_b)
+			else:
+				print(msg_c)
 
 	# below is probably not needed, but ...
 	if(not error and daBus == None):

--- a/qwiic_i2c/i2c_driver.py
+++ b/qwiic_i2c/i2c_driver.py
@@ -59,7 +59,7 @@ New to qwiic? Take a look at the entire [SparkFun qwiic ecosystem](https://www.s
 
 """
 
-from __future__ import print_function
+#from __future__ import print_function
 
 
 #-----------------------------------------------------------------------------

--- a/qwiic_i2c/linux_i2c.py
+++ b/qwiic_i2c/linux_i2c.py
@@ -36,7 +36,7 @@
 # SOFTWARE.
 #==================================================================================
 
-from __future__ import print_function
+#from __future__ import print_function
 
 from .i2c_driver import I2CDriver
 


### PR DESCRIPTION
I have modified the code to work with the current version of Circuit Python ( 8.0.4). I have currently tested this on a SAMD51 Thing Plus and ESP32-S2 and S3 QT-PYs. 

Right now I have only fully tested read and write byte and I commented out the "future" import from all the source files that had it. This may not be the ideal solution, but I wanted to submit this to get the conversation started.

Summary of Changes:

- Commented out future imports 
- Added ability to connect to I2C bus using busio.I2c or board.STEMMA_I2C() for adafruit boards
- Updated the read and write functions to match how the current version of busio sends and receives data
- Added more boards to the isPlatform function

Any feedback would be greatly appreciated. Also, if any more information is needed, please let me know.

