### PR TITLE
V1.0.0

### DIFF
--- a/qwiic_i2c/__init__.py
+++ b/qwiic_i2c/__init__.py
@@ -91,7 +91,7 @@ _theDriver = None
 #
 # If no driver is found, a None value is returned
 
-def getI2CDriver():
+def getI2CDriver(*args, **argk):
 	"""
 	.. function:: getI2CDriver()
 
@@ -119,13 +119,13 @@ def getI2CDriver():
 		# Does this class/driverd support this platform?
 		if driverClass.isPlatform():
 
-			_theDriver = driverClass()
+			_theDriver = driverClass(*args, **argk)
 			# Yes - return the driver object
 			return _theDriver
 
 	return None
 
-def get_i2c_driver():
+def get_i2c_driver(*args, **argk):
 	"""
 	.. function:: get_i2c_driver()
 
@@ -140,12 +140,12 @@ def get_i2c_driver():
 		>>> i2cDriver = qwiic_i2c.get_i2c_driver()
 		>>> myData = i2cDriver.readByte(0x73, 0x34)
 	"""
-	return getI2CDriver()
+	return getI2CDriver(*args, **argk)
 
 #-------------------------------------------------
 # Method to determine if a particular device (at the provided address)
 # is connected to the bus.
-def isDeviceConnected(devAddress):
+def isDeviceConnected(devAddress, *args, **argk):
 	"""
 	.. function:: isDeviceConnected()
 
@@ -158,7 +158,7 @@ def isDeviceConnected(devAddress):
 		:rtype: bool
 
 	"""
-	i2c = getI2CDriver()
+	i2c = getI2CDriver(*args, **argk)
 
 	if not i2c:
 		print("Unable to load the I2C driver for this device")
@@ -166,7 +166,7 @@ def isDeviceConnected(devAddress):
 	
 	return i2c.isDeviceConnected(devAddress)
 
-def is_device_connected(devAddress):
+def is_device_connected(devAddress, *args, **argk):
 	"""
 	.. function:: is_device_connected()
 
@@ -179,12 +179,12 @@ def is_device_connected(devAddress):
 		:rtype: bool
 
 	"""
-	return isDeviceConnected(devAddress)
+	return isDeviceConnected(devAddress, *args, **argk)
 
 #-------------------------------------------------
 # Method to determine if a particular device (at the provided address)
 # is connected to the bus.
-def ping(devAddress):
+def ping(devAddress, *args, **argk):
 	"""
 	.. function:: ping()
 
@@ -197,4 +197,4 @@ def ping(devAddress):
 		:rtype: bool
 
 	"""
-	return isDeviceConnected(devAddress)
+	return isDeviceConnected(devAddress, *args, **argk)

--- a/qwiic_i2c/__init__.py
+++ b/qwiic_i2c/__init__.py
@@ -147,16 +147,4 @@ def isDeviceConnected(devAddress):
 		print("Unable to load the I2C driver for this device")
 		return False
 	
-	isConnected = False
-	try:
-		# Try to write a byte to the device, command 0x0
-		# If it throws an I/O error - the device isn't connected
-		with i2c as i2cDriver:
-			i2cDriver.writeCommand(devAddress, 0x0)
-
-			isConnected = True
-	except Exception as ee:
-		print("Error connecting to Device: %X, %s" % (devAddress, ee))
-		pass
-
-	return isConnected
+	return i2c.isDeviceConnected(devAddress)

--- a/qwiic_i2c/__init__.py
+++ b/qwiic_i2c/__init__.py
@@ -84,8 +84,6 @@ for module_name, class_name in _supported_platforms.items():
 	except:
 		pass
 
-_theDriver = None
-
 #-------------------------------------------------
 # Exported method to get the I2C driver for the execution plaform. 
 #
@@ -107,21 +105,13 @@ def getI2CDriver(*args, **argk):
 		>>> myData = i2cDriver.readByte(0x73, 0x34)
 	"""
 
-	global _theDriver
-
-	if _theDriver != None:
-		return _theDriver
-
-	
-
 	for driverClass in _drivers:
 
 		# Does this class/driverd support this platform?
 		if driverClass.isPlatform():
 
-			_theDriver = driverClass(*args, **argk)
 			# Yes - return the driver object
-			return _theDriver
+			return driverClass(*args, **argk)
 
 	return None
 

--- a/qwiic_i2c/__init__.py
+++ b/qwiic_i2c/__init__.py
@@ -148,3 +148,21 @@ def isDeviceConnected(devAddress):
 		return False
 	
 	return i2c.isDeviceConnected(devAddress)
+
+#-------------------------------------------------
+# Method to determine if a particular device (at the provided address)
+# is connected to the bus.
+def ping(devAddress):
+	"""
+	.. function:: ping()
+
+		Function to determine if a particular device (at the provided address)
+		is connected to the bus.
+
+		:param devAddress: The I2C address of the device to check
+
+		:return: True if the device is connected, otherwise False.
+		:rtype: bool
+
+	"""
+	return isDeviceConnected(devAddress)

--- a/qwiic_i2c/__init__.py
+++ b/qwiic_i2c/__init__.py
@@ -84,11 +84,12 @@ for module_name, class_name in _supported_platforms.items():
 	except:
 		pass
 
+_default_driver = None
+
 #-------------------------------------------------
 # Exported method to get the I2C driver for the execution plaform. 
 #
 # If no driver is found, a None value is returned
-
 def getI2CDriver(*args, **argk):
 	"""
 	.. function:: getI2CDriver()
@@ -105,14 +106,25 @@ def getI2CDriver(*args, **argk):
 		>>> myData = i2cDriver.readByte(0x73, 0x34)
 	"""
 
+	# If no parameters are provided, return the default driver if we have it
+	global _default_driver
+	if len(argk) == 0 and _default_driver != None:
+		return _default_driver
+	
+	# Loop through all the drivers to find the one for this platform
 	for driverClass in _drivers:
-
-		# Does this class/driverd support this platform?
 		if driverClass.isPlatform():
+			# Found it!
+			driver = driverClass(*args, **argk)
 
-			# Yes - return the driver object
-			return driverClass(*args, **argk)
-
+			# If no parameters are provided, set this as the default driver
+			if len(argk) == 0:
+				_default_driver = driver
+			
+			# And return it
+			return driver
+	
+	# If we get here, we didn't find a driver for this platform
 	return None
 
 def get_i2c_driver(*args, **argk):

--- a/qwiic_i2c/__init__.py
+++ b/qwiic_i2c/__init__.py
@@ -125,6 +125,23 @@ def getI2CDriver():
 
 	return None
 
+def get_i2c_driver():
+	"""
+	.. function:: get_i2c_driver()
+
+		Returns the qwiic I2C driver object for current platform.
+
+		:return: A qwiic I2C driver object for the current platform.
+		:rtype: object
+
+		:example:
+
+		>>> import qwiic_i2c
+		>>> i2cDriver = qwiic_i2c.get_i2c_driver()
+		>>> myData = i2cDriver.readByte(0x73, 0x34)
+	"""
+	return getI2CDriver()
+
 #-------------------------------------------------
 # Method to determine if a particular device (at the provided address)
 # is connected to the bus.
@@ -148,6 +165,21 @@ def isDeviceConnected(devAddress):
 		return False
 	
 	return i2c.isDeviceConnected(devAddress)
+
+def is_device_connected(devAddress):
+	"""
+	.. function:: is_device_connected()
+
+		Function to determine if a particular device (at the provided address)
+		is connected to the bus.
+
+		:param devAddress: The I2C address of the device to check
+
+		:return: True if the device is connected, otherwise False.
+		:rtype: bool
+
+	"""
+	return isDeviceConnected(devAddress)
 
 #-------------------------------------------------
 # Method to determine if a particular device (at the provided address)

--- a/qwiic_i2c/circuitpy_i2c.py
+++ b/qwiic_i2c/circuitpy_i2c.py
@@ -149,8 +149,13 @@ class CircuitPythonI2C(I2CDriver):
 
 		buffer = bytearray(2)
 
-		self.i2cbus.writeto_then_readfrom(address, bytes([commandCode]), buffer)
-		self.i2cbus.unlock()
+		try:
+			self.i2cbus.writeto_then_readfrom(address, bytes([commandCode]), buffer)
+		except Exception as e:
+			self.i2cbus.unlock()
+			raise e
+		else:
+			self.i2cbus.unlock()
 
 		# build and return a word
 		return (buffer[1] << 8 ) | buffer[0]
@@ -163,8 +168,13 @@ class CircuitPythonI2C(I2CDriver):
 
 		buffer = bytearray(1)
 
-		self.i2cbus.writeto_then_readfrom(address, bytes([commandCode]), buffer)
-		self.i2cbus.unlock()
+		try:
+			self.i2cbus.writeto_then_readfrom(address, bytes([commandCode]), buffer)
+		except Exception as e:
+			self.i2cbus.unlock()
+			raise e
+		else:
+			self.i2cbus.unlock()
 
 		return buffer[0]
 
@@ -176,8 +186,13 @@ class CircuitPythonI2C(I2CDriver):
 
 		buffer = bytearray(nBytes)
 
-		self.i2cbus.writeto_then_readfrom(address, bytes([commandCode]), buffer)
-		self.i2cbus.unlock()
+		try:
+			self.i2cbus.writeto_then_readfrom(address, bytes([commandCode]), buffer)
+		except Exception as e:
+			self.i2cbus.unlock()
+			raise e
+		else:
+			self.i2cbus.unlock()
 
 		return list(buffer)
 
@@ -194,8 +209,13 @@ class CircuitPythonI2C(I2CDriver):
 		if not self.i2cbus.try_lock():
 			return None
 		
-		self.i2cbus.writeto(address, bytes([commandCode]))
-		self.i2cbus.unlock()
+		try:
+			self.i2cbus.writeto(address, bytes([commandCode]))
+		except Exception as e:
+			self.i2cbus.unlock()
+			raise e
+		else:
+			self.i2cbus.unlock()
 
 	#----------------------------------------------------------
 	def writeWord(self, address, commandCode, value):
@@ -206,8 +226,13 @@ class CircuitPythonI2C(I2CDriver):
 		buffer[0] = value & 0xFF
 		buffer[1] = (value >> 8) & 0xFF
 
-		self.i2cbus.writeto(address, bytes([commandCode] + buffer))
-		self.i2cbus.unlock()
+		try:
+			self.i2cbus.writeto(address, bytes([commandCode] + buffer))
+		except Exception as e:
+			self.i2cbus.unlock()
+			raise e
+		else:
+			self.i2cbus.unlock()
 
 
 	#----------------------------------------------------------
@@ -215,16 +240,26 @@ class CircuitPythonI2C(I2CDriver):
 		if not self.i2cbus.try_lock():
 			return None
 		
-		self.i2cbus.writeto(address, bytes([commandCode] + [value]))
-		self.i2cbus.unlock()
+		try:
+			self.i2cbus.writeto(address, bytes([commandCode] + [value]))
+		except Exception as e:
+			self.i2cbus.unlock()
+			raise e
+		else:
+			self.i2cbus.unlock()
 
 	#----------------------------------------------------------
 	def writeBlock(self, address, commandCode, value):
 		if not self.i2cbus.try_lock():
 			return None
 		
-		self.i2cbus.writeto(address, bytes([commandCode] + value))
-		self.i2cbus.unlock()
+		try:
+			self.i2cbus.writeto(address, bytes([commandCode] + value))
+		except Exception as e:
+			self.i2cbus.unlock()
+			raise e
+		else:
+			self.i2cbus.unlock()
 
 	@classmethod
 	def isDeviceConnected(cls, devAddress):
@@ -240,11 +275,12 @@ class CircuitPythonI2C(I2CDriver):
 			# Try to write nothing to the device
 			# If it throws an I/O error - the device isn't connected
 			cls._i2cbus.writeto(devAddress, bytearray())
-			cls._i2cbus.unlock()
 			isConnected = True
 		except Exception as ee:
 			print("Error connecting to Device: %X, %s" % (devAddress, ee))
 			pass
+		finally:
+			cls._i2cbus.unlock()
 
 		return isConnected
 

--- a/qwiic_i2c/circuitpy_i2c.py
+++ b/qwiic_i2c/circuitpy_i2c.py
@@ -85,6 +85,9 @@ def _connectToI2CBus():
 
 	return daBus
 
+def _connect_to_i2c_bus():
+	return _connectToI2CBus()
+
 # notes on determining CirPy platform
 #
 # - os.uname().sysname == samd*
@@ -110,6 +113,10 @@ class CircuitPythonI2C(I2CDriver):
 			return 'circuitpython' in sys.implementation
 		except:
 			return False
+
+	@classmethod
+	def is_platform(cls):
+		return cls.isPlatform()
 
 #-------------------------------------------------------------------------		
 	# General get attribute method
@@ -159,6 +166,9 @@ class CircuitPythonI2C(I2CDriver):
 		# build and return a word
 		return (buffer[1] << 8 ) | buffer[0]
 
+	def read_word(self, address, commandCode):
+		return self.readWord(address, commandCode)
+
 	#----------------------------------------------------------
 	def readByte(self, address, commandCode):
 		if not self.i2cbus.try_lock():
@@ -175,6 +185,9 @@ class CircuitPythonI2C(I2CDriver):
 			self.i2cbus.unlock()
 
 		return buffer[0]
+
+	def read_byte(self, address, commandCode = None):
+		return self.readByte(address, commandCode)
 
 	#----------------------------------------------------------
 	def readBlock(self, address, commandCode, nBytes):
@@ -193,7 +206,9 @@ class CircuitPythonI2C(I2CDriver):
 
 		return list(buffer)
 
-		
+	def read_block(self, address, commandCode, nBytes):
+		return self.readBlock(address, commandCode, nBytes)
+
 	#--------------------------------------------------------------------------	
 	# write Data Commands 
 	#
@@ -214,6 +229,9 @@ class CircuitPythonI2C(I2CDriver):
 		else:
 			self.i2cbus.unlock()
 
+	def write_command(self, address, commandCode):
+		return self.writeCommand(address, commandCode)
+
 	#----------------------------------------------------------
 	def writeWord(self, address, commandCode, value):
 		if not self.i2cbus.try_lock():
@@ -231,6 +249,9 @@ class CircuitPythonI2C(I2CDriver):
 		else:
 			self.i2cbus.unlock()
 
+	def write_word(self, address, commandCode, value):
+		return self.writeWord(address, commandCode, value)
+
 	#----------------------------------------------------------
 	def writeByte(self, address, commandCode, value):
 		if not self.i2cbus.try_lock():
@@ -244,6 +265,9 @@ class CircuitPythonI2C(I2CDriver):
 		else:
 			self.i2cbus.unlock()
 
+	def write_byte(self, address, commandCode, value):
+		return self.writeByte(address, commandCode, value)
+
 	#----------------------------------------------------------
 	def writeBlock(self, address, commandCode, value):
 		if not self.i2cbus.try_lock():
@@ -256,6 +280,9 @@ class CircuitPythonI2C(I2CDriver):
 			raise e
 		else:
 			self.i2cbus.unlock()
+
+	def write_block(self, address, commandCode, value):
+		return self.writeBlock(address, commandCode, value)
 
 	@classmethod
 	def isDeviceConnected(cls, devAddress):
@@ -279,6 +306,10 @@ class CircuitPythonI2C(I2CDriver):
 			cls._i2cbus.unlock()
 
 		return isConnected
+
+	@classmethod
+	def is_device_connected(cls, devAddress):
+		return cls.isDeviceConnected(devAddress)
 
 	@classmethod
 	def ping(cls, devAddress):

--- a/qwiic_i2c/circuitpy_i2c.py
+++ b/qwiic_i2c/circuitpy_i2c.py
@@ -245,6 +245,10 @@ class CircuitPythonI2C(I2CDriver):
 
 		return isConnected
 
+	@classmethod
+	def ping(cls, devAddress):
+		return cls.isDeviceConnected(devAddress)
+
 	#-----------------------------------------------------------------------
 	# scan()
 	#

--- a/qwiic_i2c/circuitpy_i2c.py
+++ b/qwiic_i2c/circuitpy_i2c.py
@@ -223,8 +223,27 @@ class CircuitPythonI2C(I2CDriver):
 		self.i2cbus.writeto(address, bytes([commandCode] + value))
 		self.i2cbus.unlock()
 
+	@classmethod
+	def isDeviceConnected(cls, devAddress):
+		if cls._i2cbus == None:
+			cls._i2cbus = _connectToI2CBus()
+		if cls._i2cbus == None:
+			return False
+		if not cls._i2cbus.try_lock():
+			return False
 
+		isConnected = False
+		try:
+			# Try to write nothing to the device
+			# If it throws an I/O error - the device isn't connected
+			cls._i2cbus.writeto(devAddress, bytearray())
+			cls._i2cbus.unlock()
+			isConnected = True
+		except Exception as ee:
+			print("Error connecting to Device: %X, %s" % (devAddress, ee))
+			pass
 
+		return isConnected
 
 	#-----------------------------------------------------------------------
 	# scan()

--- a/qwiic_i2c/circuitpy_i2c.py
+++ b/qwiic_i2c/circuitpy_i2c.py
@@ -65,7 +65,10 @@ def _connectToI2CBus():
 	# Connect - catch errors 
 
 	try:
-		daBus =  busio.I2C(board.GP1, board.GP0, frequency=400000)
+		if hasattr(board, "STEMMA_I2C"):
+			daBus = board.STEMMA_I2C()
+		else:
+			daBus = busio.I2C(board.SCL, board.SDA)
 	except Exception as ee:
 		if type(ee) is RuntimeError:
 			print("Error:\tUnable to connect to I2C bus. %s" % (ee))

--- a/qwiic_i2c/circuitpy_i2c.py
+++ b/qwiic_i2c/circuitpy_i2c.py
@@ -300,8 +300,7 @@ class CircuitPythonI2C(I2CDriver):
 			# If it throws an I/O error - the device isn't connected
 			self.i2cbus.writeto(devAddress, bytearray())
 			isConnected = True
-		except Exception as ee:
-			print("Error connecting to Device: %X, %s" % (devAddress, ee))
+		except:
 			pass
 		finally:
 			self.i2cbus.unlock()

--- a/qwiic_i2c/circuitpy_i2c.py
+++ b/qwiic_i2c/circuitpy_i2c.py
@@ -143,9 +143,8 @@ class CircuitPythonI2C(I2CDriver):
 	# read Data Command
 
 	def readWord(self, address, commandCode):
-
 		if not self.i2cbus.try_lock():
-			return None
+			raise Exception("Unable to lock I2C bus")
 
 		buffer = bytearray(2)
 
@@ -162,9 +161,8 @@ class CircuitPythonI2C(I2CDriver):
 
 	#----------------------------------------------------------
 	def readByte(self, address, commandCode):
-
 		if not self.i2cbus.try_lock():
-			return None
+			raise Exception("Unable to lock I2C bus")
 
 		buffer = bytearray(1)
 
@@ -180,9 +178,8 @@ class CircuitPythonI2C(I2CDriver):
 
 	#----------------------------------------------------------
 	def readBlock(self, address, commandCode, nBytes):
-
 		if not self.i2cbus.try_lock():
-			return None
+			raise Exception("Unable to lock I2C bus")
 
 		buffer = bytearray(nBytes)
 
@@ -207,7 +204,7 @@ class CircuitPythonI2C(I2CDriver):
 
 	def writeCommand(self, address, commandCode):
 		if not self.i2cbus.try_lock():
-			return None
+			raise Exception("Unable to lock I2C bus")
 		
 		try:
 			self.i2cbus.writeto(address, bytes([commandCode]))
@@ -220,7 +217,7 @@ class CircuitPythonI2C(I2CDriver):
 	#----------------------------------------------------------
 	def writeWord(self, address, commandCode, value):
 		if not self.i2cbus.try_lock():
-			return None
+			raise Exception("Unable to lock I2C bus")
 
 		buffer = [0, 0]
 		buffer[0] = value & 0xFF
@@ -234,11 +231,10 @@ class CircuitPythonI2C(I2CDriver):
 		else:
 			self.i2cbus.unlock()
 
-
 	#----------------------------------------------------------
 	def writeByte(self, address, commandCode, value):
 		if not self.i2cbus.try_lock():
-			return None
+			raise Exception("Unable to lock I2C bus")
 		
 		try:
 			self.i2cbus.writeto(address, bytes([commandCode] + [value]))
@@ -251,7 +247,7 @@ class CircuitPythonI2C(I2CDriver):
 	#----------------------------------------------------------
 	def writeBlock(self, address, commandCode, value):
 		if not self.i2cbus.try_lock():
-			return None
+			raise Exception("Unable to lock I2C bus")
 		
 		try:
 			self.i2cbus.writeto(address, bytes([commandCode] + value))

--- a/qwiic_i2c/i2c_driver.py
+++ b/qwiic_i2c/i2c_driver.py
@@ -78,7 +78,7 @@ class I2CDriver(object):
 	# stubs
 	name = 'qwiic I2C abstract base class'
 
-	def __init__(self):
+	def __init__(self, *args, **argk):
 		pass
 
 
@@ -313,8 +313,7 @@ class I2CDriver(object):
 		"""
 		return None
 
-	@classmethod
-	def isDeviceConnected(cls, devAddress):
+	def isDeviceConnected(self, devAddress):
 		"""
 			Determines if a particular device (at the provided address)
 			is connected to the bus.
@@ -327,8 +326,7 @@ class I2CDriver(object):
 		"""
 		return None
 
-	@classmethod
-	def is_device_connected(cls, devAddress):
+	def is_device_connected(self, devAddress):
 		"""
 			Determines if a particular device (at the provided address)
 			is connected to the bus.
@@ -341,8 +339,7 @@ class I2CDriver(object):
 		"""
 		return None
 
-	@classmethod
-	def ping(cls, devAddress):
+	def ping(self, devAddress):
 		"""
 			Determines if a particular device (at the provided address)
 			is connected to the bus.
@@ -355,8 +352,7 @@ class I2CDriver(object):
 		"""
 		return None
 
-	@classmethod
-	def scan(cls):
+	def scan(self):
 		"""
 			Used to scan the I2C bus, returning a list of I2C address attached to the computer.
 

--- a/qwiic_i2c/i2c_driver.py
+++ b/qwiic_i2c/i2c_driver.py
@@ -214,6 +214,20 @@ class I2CDriver(object):
 		pass
 
 	@classmethod
+	def isDeviceConnected(cls, devAddress):
+		"""
+			Determines if a particular device (at the provided address)
+			is connected to the bus.
+
+			:param devAddress: The I2C address of the device to check
+
+			:return: True if the device is connected, otherwise False.
+			:rtype: bool
+
+		"""
+		return None
+
+	@classmethod
 	def scan(cls):
 		"""
 			Used to scan the I2C bus, returning a list of I2C address attached to the computer.
@@ -223,6 +237,3 @@ class I2CDriver(object):
 
 		"""
 		return None
-
-
-

--- a/qwiic_i2c/i2c_driver.py
+++ b/qwiic_i2c/i2c_driver.py
@@ -95,6 +95,16 @@ class I2CDriver(object):
 		"""
 		pass
 
+	@classmethod
+	def is_platform(cls):
+		""" 
+			Called to determine if the specific driver supports the current platorm
+
+			:return: True if this platform is supported, otherwise False
+			:rtype: bool
+
+		"""
+		pass
 
 	#-------------------------------------------------------------------------	
 	# stubs to support Python with statements. 
@@ -124,7 +134,33 @@ class I2CDriver(object):
 		"""
 		return None
 
+	def read_word(self, address, commandCode):
+		""" 
+			Called to read a word (16 bits) from a specific device.
+
+			:param address: The I2C address of the device to read from
+			:param commandCode: The "command" or register to read from 
+
+			:return: Returns the read data
+			:rtype: integer - first 16 bits contain the read data. 
+
+		"""
+		return None
+
 	def readByte(self, address, commandCode):
+		""" 
+			Called to read a byte (8 bits) from a specific device.
+
+			:param address: The I2C address of the device to read from
+			:param commandCode: The "command" or register to read from 
+
+			:return: Returns the read data
+			:rtype: integer - first 8 bits contain the read data. 
+
+		"""
+		return None
+
+	def read_byte(self, address, commandCode):
 		""" 
 			Called to read a byte (8 bits) from a specific device.
 
@@ -150,7 +186,21 @@ class I2CDriver(object):
 
 		"""
 		return None
-		
+	
+	def read_block(self, address, commandCode, nBytes):
+		""" 
+			Called to read a block of bytesfrom a specific device.
+
+			:param address: The I2C address of the device to read from
+			:param commandCode: The "command" or register to read from
+			:param nBytes: The number of bytes to read from the device
+
+			:return: Returns the read data as a list of integers.
+			:rtype: list 
+
+		"""
+		return None
+	
 	#--------------------------------------------------------------------------	
 	# write Data Commands 
 	#
@@ -160,6 +210,18 @@ class I2CDriver(object):
 	#
 
 	def writeCommand(self, address, commandCode):
+		""" 
+			Called to write a command to a device. No actual data is written
+
+			:param address: The I2C address of the device to read from
+			:param commandCode: The "command" or register to read from 
+
+			:return: None
+
+		"""
+		return None
+
+	def write_command(self, address, commandCode):
 		""" 
 			Called to write a command to a device. No actual data is written
 
@@ -185,6 +247,18 @@ class I2CDriver(object):
 
 		return None
 
+	def write_word(self, address, commandCode, value):
+		""" 
+			Called to write a word (16 bits) to a device. 
+
+			:param address: The I2C address of the device to read from
+			:param commandCode: The "command" or register to read from
+			:param value: The word (16 bits) to write to the I2C bus
+
+			:return: None
+
+		"""
+		return None
 
 	def writeByte(self, address, commandCode, value):
 		""" 
@@ -200,6 +274,19 @@ class I2CDriver(object):
 
 		return None
 
+	def write_byte(self, address, commandCode, value):
+		""" 
+			Called to write a byte (8 bits) to a device. 
+
+			:param address: The I2C address of the device to read from
+			:param commandCode: The "command" or register to read from
+			:param value: The byte (8 bits) to write to the I2C bus
+
+			:return: None
+
+		"""
+		return None
+
 	def writeBlock(self, address, commandCode, value):
 		""" 
 			Called to write a block of bytes to a device. 
@@ -213,8 +300,35 @@ class I2CDriver(object):
 		"""
 		pass
 
+	def write_block(self, address, commandCode, value):
+		""" 
+			Called to write a block of bytes to a device. 
+
+			:param address: The I2C address of the device to read from
+			:param commandCode: The "command" or register to read from
+			:param value: A list of bytes (ints) to write on the I2C bus.
+
+			:return: None
+
+		"""
+		return None
+
 	@classmethod
 	def isDeviceConnected(cls, devAddress):
+		"""
+			Determines if a particular device (at the provided address)
+			is connected to the bus.
+
+			:param devAddress: The I2C address of the device to check
+
+			:return: True if the device is connected, otherwise False.
+			:rtype: bool
+
+		"""
+		return None
+
+	@classmethod
+	def is_device_connected(cls, devAddress):
 		"""
 			Determines if a particular device (at the provided address)
 			is connected to the bus.

--- a/qwiic_i2c/i2c_driver.py
+++ b/qwiic_i2c/i2c_driver.py
@@ -228,6 +228,20 @@ class I2CDriver(object):
 		return None
 
 	@classmethod
+	def ping(cls, devAddress):
+		"""
+			Determines if a particular device (at the provided address)
+			is connected to the bus.
+
+			:param devAddress: The I2C address of the device to check
+
+			:return: True if the device is connected, otherwise False.
+			:rtype: bool
+
+		"""
+		return None
+
+	@classmethod
 	def scan(cls):
 		"""
 			Used to scan the I2C bus, returning a list of I2C address attached to the computer.

--- a/qwiic_i2c/linux_i2c.py
+++ b/qwiic_i2c/linux_i2c.py
@@ -279,7 +279,12 @@ class LinuxI2C(I2CDriver):
 	#
 	def scan(self):
 		""" Returns a list of addresses for the devices connected to the I2C bus."""
-		return self.i2cbus.scan()
+		foundDevices = []
+		# Loop over the list of legal addresses (0x08 - 0x77)
+		for currAddress in range(0x08, 0x78):
+			if self.ping(currAddress) == True:
+				foundDevices.append(currAddress)
+		return foundDevices
 
 	#-----------------------------------------------------------------------
 	# Custom method for reading +8-bit register using `i2c_msg` from `smbus2`

--- a/qwiic_i2c/linux_i2c.py
+++ b/qwiic_i2c/linux_i2c.py
@@ -230,6 +230,26 @@ class LinuxI2C(I2CDriver):
 		tmpVal = list(value) if type(value) == bytearray else value
 		self.i2cbus.write_i2c_block_data(address, commandCode, tmpVal)
 
+	@classmethod
+	def isDeviceConnected(cls, devAddress):
+		if cls._i2cbus == None:
+			cls._i2cbus = _connectToI2CBus()
+		
+		if cls._i2cbus == None:
+			return False
+		
+		isConnected = False
+		try:
+			# Try to write nothing to the device
+			# If it throws an I/O error - the device isn't connected
+			cls._i2cbus.write_quick(devAddress)
+			isConnected = True
+		except Exception as ee:
+			print("Error connecting to Device: %X, %s" % (devAddress, ee))
+			pass
+		
+		return isConnected
+
 	#-----------------------------------------------------------------------
 	# scan()
 	#

--- a/qwiic_i2c/linux_i2c.py
+++ b/qwiic_i2c/linux_i2c.py
@@ -250,6 +250,10 @@ class LinuxI2C(I2CDriver):
 		
 		return isConnected
 
+	@classmethod
+	def ping(cls, devAddress):
+		return cls.isDeviceConnected(devAddress)
+
 	#-----------------------------------------------------------------------
 	# scan()
 	#

--- a/qwiic_i2c/linux_i2c.py
+++ b/qwiic_i2c/linux_i2c.py
@@ -82,6 +82,8 @@ def _connectToI2CBus():
 
 	return daBus
 
+def _connect_to_i2c_bus():
+	return _connectToI2CBus()
 
 # notes on determining Linux platform
 #
@@ -115,6 +117,9 @@ class LinuxI2C(I2CDriver):
 
 		return sys.platform in ('linux', 'linux2')
 
+	@classmethod
+	def is_platform(cls):
+		return cls.isPlatform()
 
 #-------------------------------------------------------------------------		
 	# General get attribute method
@@ -166,6 +171,9 @@ class LinuxI2C(I2CDriver):
 
 		return data
 
+	def read_word(self, address, commandCode):
+		return self.readWord(address, commandCode)
+
 	def readByte(self, address, commandCode = None):
 		data = 0
 		for i in range(_retry_count):
@@ -185,6 +193,8 @@ class LinuxI2C(I2CDriver):
 
 		return data
 
+	def read_byte(self, address, commandCode = None):
+		return self.readByte(address, commandCode)
 
 	def readBlock(self, address, commandCode, nBytes):
 		data = 0
@@ -201,7 +211,10 @@ class LinuxI2C(I2CDriver):
 				pass
 
 		return data
-		
+
+	def read_block(self, address, commandCode, nBytes):
+		return self.readBlock(address, commandCode, nBytes)
+
 	#--------------------------------------------------------------------------	
 	# write Data Commands 
 	#
@@ -214,14 +227,22 @@ class LinuxI2C(I2CDriver):
 
 		return self.i2cbus.write_byte(address, commandCode)
 
+	def write_command(self, address, commandCode):
+		return self.writeCommand(address, commandCode)
+
 	def writeWord(self, address, commandCode, value):
 
 		return self.i2cbus.write_word_data(address, commandCode, value)
 
+	def write_word(self, address, commandCode, value):
+		return self.writeWord(address, commandCode, value)
 
 	def writeByte(self, address, commandCode, value):
 
 		return self.i2cbus.write_byte_data(address, commandCode, value)
+
+	def write_byte(self, address, commandCode, value):
+		return self.writeByte(address, commandCode, value)
 
 	def writeBlock(self, address, commandCode, value):
 
@@ -229,6 +250,9 @@ class LinuxI2C(I2CDriver):
 		# required by this call)
 		tmpVal = list(value) if type(value) == bytearray else value
 		self.i2cbus.write_i2c_block_data(address, commandCode, tmpVal)
+
+	def write_block(self, address, commandCode, value):
+		return self.writeBlock(address, commandCode, value)
 
 	@classmethod
 	def isDeviceConnected(cls, devAddress):
@@ -249,6 +273,10 @@ class LinuxI2C(I2CDriver):
 			pass
 		
 		return isConnected
+
+	@classmethod
+	def is_device_connected(cls, devAddress):
+		return cls.isDeviceConnected(devAddress)
 
 	@classmethod
 	def ping(cls, devAddress):

--- a/qwiic_i2c/linux_i2c.py
+++ b/qwiic_i2c/linux_i2c.py
@@ -260,8 +260,7 @@ class LinuxI2C(I2CDriver):
 			# If it throws an I/O error - the device isn't connected
 			self.i2cbus.write_quick(devAddress)
 			isConnected = True
-		except Exception as ee:
-			print("Error connecting to Device: %X, %s" % (devAddress, ee))
+		except:
 			pass
 		
 		return isConnected

--- a/qwiic_i2c/micropython_i2c.py
+++ b/qwiic_i2c/micropython_i2c.py
@@ -167,8 +167,7 @@ class MicroPythonI2C(I2CDriver):
 			# If it throws an I/O error - the device isn't connected
 			self.i2cbus.writeto(devAddress, bytearray())
 			isConnected = True
-		except Exception as ee:
-			print("Error connecting to Device: %X, %s" % (devAddress, ee))
+		except:
 			pass
 		
 		return isConnected

--- a/qwiic_i2c/micropython_i2c.py
+++ b/qwiic_i2c/micropython_i2c.py
@@ -125,6 +125,25 @@ class MicroPythonI2C(I2CDriver):
 	def writeBlock(self, address, commandCode, value):
 		self.i2cbus.writeto_mem(address, commandCode, bytes(value))
 
+	@classmethod
+	def isDeviceConnected(cls, devAddress):
+		if cls._i2cbus == None:
+			cls._i2cbus = _connectToI2CBus()
+		
+		if cls._i2cbus == None:
+			return False
+		
+		isConnected = False
+		try:
+			# Try to write nothing to the device
+			# If it throws an I/O error - the device isn't connected
+			cls._i2cbus.writeto(devAddress, bytearray())
+			isConnected = True
+		except Exception as ee:
+			print("Error connecting to Device: %X, %s" % (devAddress, ee))
+			pass
+		
+		return isConnected
 
 	# scan -------------------------------------------------------------------
 	@classmethod

--- a/qwiic_i2c/micropython_i2c.py
+++ b/qwiic_i2c/micropython_i2c.py
@@ -145,6 +145,10 @@ class MicroPythonI2C(I2CDriver):
 		
 		return isConnected
 
+	@classmethod
+	def ping(cls, devAddress):
+		return cls.isDeviceConnected(devAddress)
+
 	# scan -------------------------------------------------------------------
 	@classmethod
 	def scan(cls):

--- a/qwiic_i2c/micropython_i2c.py
+++ b/qwiic_i2c/micropython_i2c.py
@@ -55,6 +55,9 @@ def _connectToI2CBus(freq=400000):
 		print('error: failed to connect to i2c bus')
 	return None
 
+def _connect_to_i2c_bus():
+	return _connectToI2CBus()
+
 class MicroPythonI2C(I2CDriver):
 
 	# Constructor
@@ -71,6 +74,9 @@ class MicroPythonI2C(I2CDriver):
 		except:
 			return False
 
+	@classmethod
+	def is_platform(cls):
+		return cls.isPlatform()
 
 #-------------------------------------------------------------------------		
 	# General get attribute method
@@ -105,25 +111,45 @@ class MicroPythonI2C(I2CDriver):
 		buffer = self.i2cbus.readfrom_mem(address, commandCode, 2)
 		return (buffer[1] << 8 ) | buffer[0]
 
+	def read_word(self, address, commandCode):
+		return self.readWord(address, commandCode)
+
 	def readByte(self, address, commandCode):
 		return self.i2cbus.readfrom_mem(address, commandCode, 1)[0]
+
+	def read_byte(self, address, commandCode = None):
+		return self.readByte(address, commandCode)
 
 	def readBlock(self, address, commandCode, nBytes):
 		return self.i2cbus.readfrom_mem(address, commandCode, nBytes)
 
-		
+	def read_block(self, address, commandCode, nBytes):
+		return self.readBlock(address, commandCode, nBytes)
+
 	# write commands----------------------------------------------------------
 	def writeCommand(self, address, commandCode):
 		self.i2cbus.writeto(address, commandCode.to_bytes(1, 'little'))
 
+	def write_command(self, address, commandCode):
+		return self.writeCommand(address, commandCode)
+
 	def writeWord(self, address, commandCode, value):
 		self.i2cbus.writeto_mem(address, commandCode, value.to_bytes(2, 'little'))
+
+	def write_word(self, address, commandCode, value):
+		return self.writeWord(address, commandCode, value)
 
 	def writeByte(self, address, commandCode, value):
 		self.i2cbus.writeto_mem(address, commandCode, value.to_bytes(1, 'little'))
 
+	def write_byte(self, address, commandCode, value):
+		return self.writeByte(address, commandCode, value)
+
 	def writeBlock(self, address, commandCode, value):
 		self.i2cbus.writeto_mem(address, commandCode, bytes(value))
+
+	def write_block(self, address, commandCode, value):
+		return self.writeBlock(address, commandCode, value)
 
 	@classmethod
 	def isDeviceConnected(cls, devAddress):
@@ -144,6 +170,10 @@ class MicroPythonI2C(I2CDriver):
 			pass
 		
 		return isConnected
+
+	@classmethod
+	def is_device_connected(cls, devAddress):
+		return cls.isDeviceConnected(devAddress)
 
 	@classmethod
 	def ping(cls, devAddress):

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.10.0',
+    version='1.0.0',
 
     description='SparkFun Electronics qwiic I2C library',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.9.11',
+    version='0.10.0',
 
     description='SparkFun Electronics qwiic I2C library',
     long_description=long_description,


### PR DESCRIPTION
Overall improved I2C driver implementation!

The first major feature here is support for configuring which I2C bus to use. All currently supported platforms support this feature, and examples of how to use are below. It basically amounts to calling `qwiic_i2c.get_i2c_driver()` with whatever parameters you need for your platform. If no parameters are provided, the default bus for your platform will be chosen.

Linux:
```
# Set the corresponding bus index
my_bus = qwiic_i2c.get_i2c_driver(iBus=1)
```

CircuitPython:
```
# Set the I2C pins and optionally set the frequency (defaults to 100kHz)
my_bus = qwiic_i2c.get_i2c_driver(sda = board.GP0, sda = board.GP1, freq = 100000)
```

MicroPython:
```
# Set the I2C pins and optionally set the frequency (defaults to 100kHz)
my_bus = qwiic_i2c.get_i2c_driver(sda = 0, sda = 1, freq = 100000)
```

The second major feature is that the CircuitPython driver has been fixed to correctly lock and unlock the bus. Thanks to @prattal17 for #10!

Other minor features and fixes:

- Added snake case versions of all functions and methods to allow more Pythonic conventions
- Moved `isDeviceConnected()` into platform specific drivers in order to use the correct bus instead of just the default one
    - Also added `ping()` as a shorter alternative
- Changed `isDeviceConnected()` to no longer send an extra 0 byte. It was discovered that this can cause issues with some devices (eg. CAP1203)
- If no parameters are provided to `qwiic_i2c.get_i2c_driver()`, the default bus will be cached so that subsequent calls are faster (helps when multiple devices are used on the default bus)
- Improved CircuitPython platform detection and read/write implementations

Issues and pull requests addressed in this merge:

- Resolves #4 
- Resolves #13 
- Resolves #15 
- Resolves #1
- Resolves #8
- Resolves #9
- Resolves #10 