### PR TITLE
Add connection test support for CircuitPython on ESP32. Addresses #26.

### DIFF
--- a/qwiic_i2c/circuitpython_i2c.py
+++ b/qwiic_i2c/circuitpython_i2c.py
@@ -330,7 +330,14 @@ class CircuitPythonI2C(I2CDriver):
 			self._i2cbus.writeto(devAddress, bytearray())
 			isConnected = True
 		except:
-			pass
+				try:
+					# Some platforms (e.g. ESP32) don't like writing an empty bytearray
+					# So we will try another connection test as well:
+					buff = bytearray(1)
+					self._i2cbus.readfrom_into(devAddress, buff)
+					isConnected = True
+				except:
+					pass
 		finally:
 			self._i2cbus.unlock()
 


### PR DESCRIPTION
- Tested on a Thing Plus EPS32-C6 to confirm that isDeviceConnected() now behaves as expected on ESP32 platforms.
- Tested on a Pro Micro RP2350 to make sure Non-ESP32 platforms still behave as expected.
